### PR TITLE
Guard automation against reintroducing TypeScript 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
       prefix: "[extension]"
     assignees:
       - "alexey-max-fedorov"
+    ignore:
+      # TypeScript 7 is an ESM-only rewrite that dropped the classic
+      # lib/typescript.js CJS entry Next.js 16 requires, which breaks
+      # Vercel's build (see commit ff02942). Stay on the 6.x line until
+      # Next.js/Vercel support TS 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # website
   - package-ecosystem: "npm"
@@ -20,6 +27,9 @@ updates:
       prefix: "[website]"
     assignees:
       - "alexey-max-fedorov"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/BetterDependabot.yml
+++ b/.github/workflows/BetterDependabot.yml
@@ -28,12 +28,18 @@ jobs:
         version: 9
 
     - name: Update extension dependencies
-      run: pnpm update --latest
+      run: |
+        pnpm update --latest
+        # TypeScript 7 is an ESM-only rewrite that dropped the classic
+        # lib/typescript.js CJS entry Next.js 16 / Vercel's builder require,
+        # so it must stay pinned to the 6.x line regardless of --latest.
+        pnpm add -D typescript@^6
 
     - name: Update website dependencies
       run: |
         cd ./website/
         pnpm update --latest
+        pnpm add -D typescript@^6
 
     - name: Verify extension still builds
       run: |


### PR DESCRIPTION
## Root cause (confirmed)

This repo's only real CI check — the custom `.github/workflows/BetterDependabot.yml` job (not GitHub-native Dependabot) — has failed every night for 3 nights running (`gh run list`, runs `29218196350`, `29175754121`, `29135167844`).

That job runs `pnpm update --latest` (ignores all semver ranges, including `typescript`'s `^6.0.3` pin) and then verifies with `pnpm run typecheck`. On each run it resolves `typescript@latest` = `7.0.2`, and `tsc --noEmit` immediately fails:

```
tsconfig.json(3,3): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration.
tsconfig.json(9,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
```

I reproduced this locally against this repo's real `tsconfig.json` with a disposable TS 7.0.2 install (`pnpm dlx --package typescript@7.0.2 tsc --noEmit --project tsconfig.json`) — identical TS5108/TS5102 errors. With the repo's pinned `typescript@6.0.3`, `pnpm run typecheck` / `pnpm run build` pass clean on both the extension and the website.

This is also not a new problem: commit `ff02942` ("Pin typescript back to ^6.0.3 to fix broken production build") already fixed this exact regression once, noting TS7's ESM-only rewrite drops the CJS entry Next.js/Vercel needs. Since then, native Dependabot (no `ignore` rule for `typescript`) has opened two new PRs proposing the same 6.0.3 → 7.0.2 bump — **#58** and **#59** — and both already show a failing Vercel deployment check, corroborating the Vercel/Next.js incompatibility independently of the tsconfig issue above.

### Hypotheses considered
- **TypeScript v7 vs v6 incompatibility from unconstrained auto-update automation** — confirmed with CI logs + local repro. This is the fix below.
- **Flaky/infra issue** — ruled out; failure is a deterministic compiler error, not a transient runner/network problem.
- **Unrelated code regression** — ruled out; `tsconfig.json` is unchanged recently, and the failure is 100% reproducible by swapping only the TypeScript version.
- **Peer-dependency conflicts (plasmo/react 18 vs 19)** — present as warnings in the logs but non-blocking; not the cause of the failing step.

## Fix

- `.github/dependabot.yml`: add an `ignore` rule (`version-update:semver-major`) for `typescript` in both the extension and website ecosystems, so Dependabot stops proposing v7 bumps. Closing #58 and #59 as a result.
- `.github/workflows/BetterDependabot.yml`: after each `pnpm update --latest`, run `pnpm add -D typescript@^6` to re-pin typescript to the latest 6.x release. Verified in isolation that this reliably pulls typescript back down to 6.x even when the update step bumped it to 7.x.
- `package.json` / `pnpm-lock.yaml` are untouched — they're already correctly pinned to `^6.0.3` from the prior manual fix; this PR just closes the automation hole that kept threatening to undo it.

## Test plan
- [x] `pnpm install && pnpm run typecheck && pnpm run build` (extension) — pass
- [x] `cd website && pnpm install && pnpm run typecheck && pnpm run build` — pass
- [x] Reproduced the exact CI error locally with a disposable TS 7.0.2 install, confirmed it disappears with the repo's pinned TS 6.0.3
- [x] Verified `pnpm add -D typescript@^6` re-pins to 6.x even starting from a `^7.0.2` range
- [x] Validated both edited YAML files parse cleanly