### PR TITLE
Fix BetterDependabot: add -w flag for root-level pnpm add

### DIFF
--- a/.github/workflows/BetterDependabot.yml
+++ b/.github/workflows/BetterDependabot.yml
@@ -33,7 +33,7 @@ jobs:
         # TypeScript 7 is an ESM-only rewrite that dropped the classic
         # lib/typescript.js CJS entry Next.js 16 / Vercel's builder require,
         # so it must stay pinned to the 6.x line regardless of --latest.
-        pnpm add -D typescript@^6
+        pnpm add -D typescript@^6 -w
 
     - name: Update website dependencies
       run: |


### PR DESCRIPTION
## Summary
- `Better Dependabot` workflow run [29298533607](https://github.com/alexey-max-fedorov/dripwriter-origin/actions/runs/29298533607) failed in the "Update extension dependencies" step with `ERR_PNPM_ADDING_TO_ROOT`.
- `pnpm-workspace.yaml` declares `packages: - "website"`, which makes the repo root itself the pnpm workspace root. Under pnpm 9 (pinned via `pnpm/action-setup@v4`), `pnpm add -D <pkg>` run from the workspace root without an explicit flag refuses to proceed and asks for `-w`/`--workspace-root`.
- This only affects the root-level step; the later "Update website dependencies" step runs from inside `./website/`, which is a workspace member (not the root), so it's unaffected and left unchanged.

## Fix
Add the `-w` flag to the root-level `pnpm add -D typescript@^6` call in `.github/workflows/BetterDependabot.yml`.

## Test plan
- [x] Ran `pnpm add -D typescript@^6 -w` locally at the repo root — succeeds with no `ERR_PNPM_ADDING_TO_ROOT` error (verification-only diff to package.json/pnpm-lock.yaml was reverted afterward since local pnpm is v11 vs CI's pinned v9, which introduced unrelated lockfile-format noise)
- [x] `pnpm run typecheck` passes at root
- [x] `pnpm run build` passes at root
- [x] `cd website && pnpm run build` passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)